### PR TITLE
Add Create Missing Labels feature for YOLO datasets

### DIFF
--- a/YoloAnnotationEditor/YoloAnnotationEditor/YoloDatasetToolsControl.xaml
+++ b/YoloAnnotationEditor/YoloAnnotationEditor/YoloDatasetToolsControl.xaml
@@ -820,6 +820,55 @@
             </ScrollViewer>
         </TabItem>
 
+        <!-- Create Missing Labels Tab -->
+        <TabItem Header="Create Missing Labels">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <StackPanel Margin="20">
+                    <TextBlock Text="Create Missing Label Files" FontSize="16" FontWeight="Bold" Margin="0,0,0,10"/>
+                    <TextBlock Text="Scans the train/val/test splits and creates an empty .txt label file for every image that is missing one."
+                               TextWrapping="Wrap" Margin="0,0,0,20"/>
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <Label Grid.Row="0" Grid.Column="0" Content="Dataset YAML File:"/>
+                        <TextBox Grid.Row="0" Grid.Column="1" Name="txtCreateMissingLabelsInput" IsReadOnly="True"/>
+                        <Button Grid.Row="0" Grid.Column="2" Name="btnBrowseCreateMissingLabels" Content="Browse..." Click="BrowseCreateMissingLabels_Click"/>
+
+                        <GroupBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" Header="Options" Margin="0,10,0,0">
+                            <StackPanel>
+                                <CheckBox Name="chkCreateMissingLabelsTrain" Content="Include train split" IsChecked="True" Margin="0,5"/>
+                                <CheckBox Name="chkCreateMissingLabelsVal" Content="Include val split" IsChecked="True" Margin="0,5"/>
+                                <CheckBox Name="chkCreateMissingLabelsTest" Content="Include test split" IsChecked="True" Margin="0,5"/>
+
+                                <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                                    <Button Name="btnCreateMissingLabels" Content="Create Missing Label Files" Click="CreateMissingLabels_Click"
+                                            MinWidth="200" Padding="10,5"/>
+                                </StackPanel>
+
+                                <StackPanel Margin="0,15,0,0">
+                                    <Label Content="Status:"/>
+                                    <TextBox Name="txtCreateMissingLabelsStatus" IsReadOnly="True" Background="LightGray"/>
+                                    <ProgressBar Name="pbCreateMissingLabelsProgress" Height="20" Margin="0,5,0,0" Minimum="0" Maximum="100"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </GroupBox>
+                    </Grid>
+
+                    <TextBox Name="txtCreateMissingLabelsLog" Height="200" Margin="0,20,0,0" IsReadOnly="True"
+                             VerticalScrollBarVisibility="Auto" TextWrapping="Wrap"/>
+                </StackPanel>
+            </ScrollViewer>
+        </TabItem>
+
         <!-- Decimal Separator Tab -->
         <TabItem Header="Decimal Separator">
             <ScrollViewer VerticalScrollBarVisibility="Auto">

--- a/YoloAnnotationEditor/YoloAnnotationEditor/YoloDatasetToolsControl.xaml.cs
+++ b/YoloAnnotationEditor/YoloAnnotationEditor/YoloDatasetToolsControl.xaml.cs
@@ -3095,5 +3095,166 @@ namespace YoloAnnotationEditor
         }
 
         #endregion
+
+        #region Create Missing Labels
+
+        private void BrowseCreateMissingLabels_Click(object sender, RoutedEventArgs e)
+        {
+            OpenFileDialog openFileDialog = new OpenFileDialog
+            {
+                Filter = "YAML files (*.yaml, *.yml)|*.yaml;*.yml|All files (*.*)|*.*",
+                Title = "Select YOLO Dataset YAML File"
+            };
+
+            openFileDialog.ShowDialog();
+
+            if (!string.IsNullOrEmpty(openFileDialog.FileName))
+            {
+                txtCreateMissingLabelsInput.Text = openFileDialog.FileName;
+            }
+        }
+
+        private async void CreateMissingLabels_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrEmpty(txtCreateMissingLabelsInput.Text))
+            {
+                System.Windows.MessageBox.Show("Please select a dataset YAML file.", "Missing Input",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            string yamlPath = txtCreateMissingLabelsInput.Text;
+            if (!File.Exists(yamlPath))
+            {
+                System.Windows.MessageBox.Show("The selected YAML file does not exist.", "Invalid File",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            string datasetPath = Path.GetDirectoryName(yamlPath);
+            if (string.IsNullOrEmpty(datasetPath))
+            {
+                System.Windows.MessageBox.Show("Could not determine dataset directory from YAML file.", "Invalid Path",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            btnCreateMissingLabels.IsEnabled = false;
+            btnBrowseCreateMissingLabels.IsEnabled = false;
+            pbCreateMissingLabelsProgress.Value = 0;
+            txtCreateMissingLabelsLog.Clear();
+
+            bool includeTrain = chkCreateMissingLabelsTrain.IsChecked ?? false;
+            bool includeVal = chkCreateMissingLabelsVal.IsChecked ?? false;
+            bool includeTest = chkCreateMissingLabelsTest.IsChecked ?? false;
+
+            await Task.Run(() => CreateMissingLabelsMethod(datasetPath, includeTrain, includeVal, includeTest));
+
+            btnCreateMissingLabels.IsEnabled = true;
+            btnBrowseCreateMissingLabels.IsEnabled = true;
+        }
+
+        private void CreateMissingLabelsMethod(string datasetPath, bool includeTrain, bool includeVal, bool includeTest)
+        {
+            var splits = new List<string>();
+            if (includeTrain) splits.Add("train");
+            if (includeVal) splits.Add("val");
+            if (includeTest) splits.Add("test");
+
+            if (splits.Count == 0)
+            {
+                LogCreateMissingLabelsMessage("No splits selected.");
+                return;
+            }
+
+            var imageExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".jpg", ".jpeg", ".png", ".bmp", ".webp" };
+
+            int totalImages = 0;
+            int createdFiles = 0;
+            int skippedFiles = 0;
+            int processedImages = 0;
+
+            // Count total images first
+            foreach (var split in splits)
+            {
+                string imagesDir = Path.Combine(datasetPath, "images", split);
+                if (Directory.Exists(imagesDir))
+                    totalImages += Directory.GetFiles(imagesDir).Count(f => imageExtensions.Contains(Path.GetExtension(f)));
+            }
+
+            if (totalImages == 0)
+            {
+                LogCreateMissingLabelsMessage("No images found in the selected splits.");
+                return;
+            }
+
+            LogCreateMissingLabelsMessage($"Found {totalImages} images across {splits.Count} split(s). Scanning...");
+
+            foreach (var split in splits)
+            {
+                string imagesDir = Path.Combine(datasetPath, "images", split);
+                string labelsDir = Path.Combine(datasetPath, "labels", split);
+
+                if (!Directory.Exists(imagesDir))
+                {
+                    LogCreateMissingLabelsMessage($"Images directory does not exist, skipping: {imagesDir}");
+                    continue;
+                }
+
+                // Ensure labels directory exists
+                Directory.CreateDirectory(labelsDir);
+
+                var imageFiles = Directory.GetFiles(imagesDir)
+                    .Where(f => imageExtensions.Contains(Path.GetExtension(f)))
+                    .ToArray();
+
+                LogCreateMissingLabelsMessage($"Processing {split} split ({imageFiles.Length} images)...");
+
+                foreach (var imageFile in imageFiles)
+                {
+                    string baseName = Path.GetFileNameWithoutExtension(imageFile);
+                    string labelPath = Path.Combine(labelsDir, baseName + ".txt");
+
+                    if (File.Exists(labelPath))
+                    {
+                        skippedFiles++;
+                    }
+                    else
+                    {
+                        File.Create(labelPath).Close();
+                        createdFiles++;
+                        LogCreateMissingLabelsMessage($"Created: {Path.GetFileName(labelPath)}");
+                    }
+
+                    processedImages++;
+                    int progress = (int)((double)processedImages / totalImages * 100);
+                    Dispatcher.Invoke(() =>
+                    {
+                        pbCreateMissingLabelsProgress.Value = progress;
+                        txtCreateMissingLabelsStatus.Text = $"Processing {processedImages}/{totalImages} images...";
+                    });
+                }
+
+                LogCreateMissingLabelsMessage($"Completed {split} split.");
+            }
+
+            LogCreateMissingLabelsMessage($"Done. Created: {createdFiles}, Already existed: {skippedFiles}.");
+            Dispatcher.Invoke(() =>
+            {
+                pbCreateMissingLabelsProgress.Value = 100;
+                txtCreateMissingLabelsStatus.Text = $"Done. Created {createdFiles} label file(s).";
+            });
+        }
+
+        private void LogCreateMissingLabelsMessage(string message)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                txtCreateMissingLabelsLog.AppendText($"[{DateTime.Now:HH:mm:ss}] {message}\n");
+                txtCreateMissingLabelsLog.ScrollToEnd();
+            });
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Summary
Added a new "Create Missing Labels" feature to the YOLO Annotation Editor that automatically generates empty label files for images that are missing corresponding `.txt` annotation files across train/val/test dataset splits.

## Key Changes
- **New UI Tab**: Added "Create Missing Labels" tab to `YoloDatasetToolsControl.xaml` with:
  - YAML file browser for dataset selection
  - Checkboxes to select which splits (train/val/test) to process
  - Progress bar and status display
  - Log output for detailed operation feedback

- **Backend Implementation**: Added three new methods to `YoloDatasetToolsControl.xaml.cs`:
  - `BrowseCreateMissingLabels_Click()`: File dialog to select dataset YAML file
  - `CreateMissingLabels_Click()`: Async handler with validation and UI state management
  - `CreateMissingLabelsMethod()`: Core logic that scans image directories and creates missing label files
  - `LogCreateMissingLabelsMessage()`: Logging utility with timestamp support

## Notable Implementation Details
- Supports multiple image formats: `.jpg`, `.jpeg`, `.png`, `.bmp`, `.webp`
- Counts total images upfront for accurate progress tracking
- Automatically creates label directories if they don't exist
- Provides detailed logging with timestamps for each operation
- Runs asynchronously to prevent UI blocking
- Disables buttons during processing and re-enables upon completion
- Validates YAML file existence and dataset path before processing
- Tracks created vs. skipped files and displays summary statistics

https://claude.ai/code/session_014zTr5TYCfvt47TPDxAivfn