### PR TITLE
Fix dataset path resolution to read 'path:' key from YAML

### DIFF
--- a/YoloAnnotationEditor/YoloAnnotationEditor/YoloDatasetToolsControl.xaml.cs
+++ b/YoloAnnotationEditor/YoloAnnotationEditor/YoloDatasetToolsControl.xaml.cs
@@ -3131,10 +3131,28 @@ namespace YoloAnnotationEditor
                 return;
             }
 
-            string datasetPath = Path.GetDirectoryName(yamlPath);
-            if (string.IsNullOrEmpty(datasetPath))
+            // Read dataset root path from the 'path:' field in the YAML
+            string datasetPath = null;
+            try
             {
-                System.Windows.MessageBox.Show("Could not determine dataset directory from YAML file.", "Invalid Path",
+                string yamlContent = File.ReadAllText(yamlPath);
+                var deserializer = new DeserializerBuilder()
+                    .WithNamingConvention(UnderscoredNamingConvention.Instance)
+                    .Build();
+                var yamlData = deserializer.Deserialize<Dictionary<string, object>>(yamlContent);
+                if (yamlData.ContainsKey("path"))
+                    datasetPath = yamlData["path"]?.ToString();
+            }
+            catch (Exception ex)
+            {
+                System.Windows.MessageBox.Show($"Failed to parse YAML file: {ex.Message}", "YAML Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            if (string.IsNullOrEmpty(datasetPath) || !Directory.Exists(datasetPath))
+            {
+                System.Windows.MessageBox.Show("The 'path' field in the YAML file is missing or points to a directory that does not exist.", "Invalid Path",
                     MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }


### PR DESCRIPTION
Instead of using the YAML file's directory, parse the YAML and read the 'path:' field to get the actual dataset root directory.

https://claude.ai/code/session_014zTr5TYCfvt47TPDxAivfn