### PR TITLE
Add Shift+Click range selection for batch image list

### DIFF
--- a/YoloAnnotationEditor/YoloAnnotationEditor/BatchLabelEditor.xaml
+++ b/YoloAnnotationEditor/YoloAnnotationEditor/BatchLabelEditor.xaml
@@ -57,7 +57,8 @@
                     <!-- Image list with checkboxes -->
                     <ListView Grid.Column="0" x:Name="LvImages"
                               ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                              BorderThickness="1" BorderBrush="#FFABADB3">
+                              BorderThickness="1" BorderBrush="#FFABADB3"
+                              PreviewMouseLeftButtonDown="LvImages_PreviewMouseLeftButtonDown">
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal" Margin="2">
@@ -80,7 +81,10 @@
                         <TextBlock Text="Filter:" Margin="0,0,0,3"/>
                         <TextBox x:Name="TxtImageFilter" TextChanged="TxtImageFilter_TextChanged" Margin="0,0,0,10"/>
 
-                        <Border Background="#F0F0F0" CornerRadius="4" Padding="8" Margin="0,10,0,0">
+                        <TextBlock Text="Tip: Hold Shift and click to select a range of images."
+                                   TextWrapping="Wrap" Foreground="Gray" FontSize="11" Margin="0,0,0,10"/>
+
+                        <Border Background="#F0F0F0" CornerRadius="4" Padding="8" Margin="0,0,0,0">
                             <StackPanel>
                                 <TextBlock Text="Selection Summary" FontWeight="SemiBold" Margin="0,0,0,5"/>
                                 <TextBlock x:Name="TxtSelectionCount" Text="0 images selected"/>

--- a/YoloAnnotationEditor/YoloAnnotationEditor/BatchLabelEditor.xaml.cs
+++ b/YoloAnnotationEditor/YoloAnnotationEditor/BatchLabelEditor.xaml.cs
@@ -256,6 +256,42 @@ namespace YoloAnnotationEditor
 
         #region Step 1: Image Selection
 
+        private int _lastClickedImageIndex = -1;
+
+        private void LvImages_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            var listViewItem = GetListViewItemFromElement(e.OriginalSource as DependencyObject);
+            if (listViewItem == null) return;
+
+            var clickedItem = listViewItem.DataContext as BatchImageItem;
+            if (clickedItem == null) return;
+
+            var currentItems = GetFilteredImages().ToList();
+            int clickedIndex = currentItems.IndexOf(clickedItem);
+            if (clickedIndex < 0) return;
+
+            if ((Keyboard.Modifiers & ModifierKeys.Shift) != 0 && _lastClickedImageIndex >= 0)
+            {
+                bool targetState = !clickedItem.IsSelected;
+                int start = Math.Min(_lastClickedImageIndex, clickedIndex);
+                int end = Math.Max(_lastClickedImageIndex, clickedIndex);
+
+                for (int i = start; i <= end; i++)
+                    currentItems[i].IsSelected = targetState;
+
+                e.Handled = true;
+            }
+
+            _lastClickedImageIndex = clickedIndex;
+        }
+
+        private static ListViewItem GetListViewItemFromElement(DependencyObject element)
+        {
+            while (element != null && element is not ListViewItem)
+                element = VisualTreeHelper.GetParent(element);
+            return element as ListViewItem;
+        }
+
         private void BtnSelectAll_Click(object sender, RoutedEventArgs e)
         {
             foreach (var item in GetFilteredImages())
@@ -279,6 +315,7 @@ namespace YoloAnnotationEditor
 
         private void TxtImageFilter_TextChanged(object sender, TextChangedEventArgs e)
         {
+            _lastClickedImageIndex = -1;
             string filter = TxtImageFilter.Text?.ToLowerInvariant() ?? "";
             if (string.IsNullOrEmpty(filter))
             {

--- a/YoloAnnotationEditor/YoloAnnotationEditor/YoloAnnotationEditor.csproj
+++ b/YoloAnnotationEditor/YoloAnnotationEditor/YoloAnnotationEditor.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>True</UseWindowsForms>
-	  <FileVersion>1.0.20</FileVersion>
+	  <FileVersion>1.0.21</FileVersion>
 	  <ApplicationIcon>Images\icon.ico</ApplicationIcon>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
This PR adds support for selecting a range of images in the batch label editor by holding Shift and clicking, improving the user experience when working with large image lists.

## Key Changes
- **Range selection with Shift+Click**: Users can now hold Shift and click on an image to select/deselect all images between the last clicked item and the current item
- **Visual feedback**: Added a helpful tip in the UI explaining the Shift+Click functionality
- **Filter state reset**: The last clicked index is reset when the image filter changes to prevent unexpected behavior
- **Helper method**: Added `GetListViewItemFromElement()` to traverse the visual tree and find the parent ListViewItem
- **Version bump**: Updated file version from 1.0.20 to 1.0.21

## Implementation Details
- The `LvImages_PreviewMouseLeftButtonDown` event handler intercepts mouse clicks on the image list
- When Shift is held, it calculates the range between the last clicked index and current index, then applies the same selection state to all items in that range
- The selection state is determined by the current state of the clicked item (toggle behavior)
- The implementation works with filtered image lists by using `GetFilteredImages()` to maintain correct indices

https://claude.ai/code/session_01HpJvbJr2YDWtmwXBm2axNJ